### PR TITLE
Feature: filenames in rules and required tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,36 +18,51 @@ Example: mtag apply rules.txt ogg
 
 To be tagged correctly, the media files names needs to be named in the alphabetical order, i.e. for example:
 
+```
 01-first-song.ogg  
 01-second-song.ogg  
 01-third-song.ogg  
+```
 
 The rules file must be in UTF-8 encoding. The rules file syntax is simple - the set of blocks with tags. Each block is ended with "\#\#\#". Example:
 
+```
+#filename: 01-first-song.ogg
 @album=testalbum  
 @artist=Megapunkers  
 @title=song one  
 \#\#\#  
+#filename: 01-second-song.ogg  
 @album=testalbum  
 @artist=Megapunkers  
 @title=song two  
 \#\#\#  
+#filename: 01-third-song.ogg  
 @album=testalbum  
 @artist=Megapunkers  
 @title=song three  
 \#\#\#
+```
 
 So the first block will be applied to the first media file at the current directory, the second block to the second file, etc. 
 
 The list of available tags: @artist, @title, @album, @genre, @comment, @year, @track.
 
+The `#filename` tag in block is ignored, it is needed just to understand which media file tags you edit now. Only the file order in directory and block order in rules file matters, not the `#filename` tag.
+
 **To extract the tags** from the media files to the rules file, use the "extract" option:
 
-mtag extract OUTPUTFILE extension
+mtag extract OUTPUTFILE extension <list_of_required_tags>
 
 For example:
 
-mtag extract RULES ogg 
+mtag extract RULES ogg
+
+or
+
+mtag extract RULES mp3 "@artist,@genre,@album"
+
+<list_of_required_tags> is an optional parameter, it defines which tags will be generated even if such data is not presented in source media file, blank values will be used.
 
 **To rename files** according their tags, use:
 
@@ -84,32 +99,47 @@ mtag apply файл_с_правилами расширение
 
 Звуковые файлы должны быть именованы по алфавиту, например:
 
+```
 01-first-song.ogg  
 01-second-song.ogg  
 01-third-song.ogg
+```
 
 Файл правил должен быть в кодировке UTF-8. Синтаксис файла прост - файл состоит из блоков тэгов, и каждый блок оканчивается "\#\#\#". Пример:
 
+```
+#filename: 01-first-song.ogg
 @album=проба  
 @artist=никто  
 @title=песенка первая  
 \#\#\#  
+#filename: 01-second-song.ogg
 @album=проба  
 @artist=никто  
 @title=песенка вторая  
 \#\#\#  
+#filename: 01-third-song.ogg
 @album=testalbum  
 @artist=никто  
 @title=песня третья  
 \#\#\#
+```
 
 Первый блок будет применен к первому файлу (с указанным расширением) в текущем каталоге, второй ко второму, и так далее.
 
 Список доступных тэгов: @artist, @title, @album, @genre, @comment, @year, @track.
 
+Тэг `#filename` в блоке игнонируется, он нужен для понимания того какой медиафайл сейчас редактируется. Только порядок файлов в каталоге и тэгов в списке правил влияет на то какой блок тэгов будет применен к какому файлу, тэг `#filename` ни на что не влияет.
+
 **Чтобы извлечь тэги из файлов в файл правил**, к командной строке надо добавить ключик "extract", например:
 
-mtag extract RULES ogg 
+mtag extract RULES ogg <список_обязательных_тэгов>
+
+или
+
+mtag extract RULES mp3 "@artist,@genre,@album"
+
+<список_обязательных_тэгов> это необязательный параметр, оперделяющий список тэгов, которые будут сгенерированы в файле правил, даже если такие тэги в медиафайле не представлены, значения таких тэгов будут пустыми.
 
 **Чтобы переименовать файлы** согласно записанным в них тэгам, используйте команду:
 

--- a/main.cpp
+++ b/main.cpp
@@ -303,7 +303,7 @@ void write_tags (const string &rules_file, const string &ext)
 }
 
 
-void extract_tags (const string &rules_file, const string &ext)
+void extract_tags (const string &rules_file, const string &ext, const string &required_tag_set)
 {
   std::vector <string> files = files_get_list (current_path(), ext);
   std::sort (files.begin(), files.end());
@@ -321,6 +321,9 @@ void extract_tags (const string &rules_file, const string &ext)
   for (size_t i = 0; i < files.size(); i++)
      {
       string fname = files[i];
+
+      string filename_comment = "#filename: " + fname;
+      vs.push_back(filename_comment);
           
       cout << "process:" << fname << endl;
       
@@ -332,8 +335,8 @@ void extract_tags (const string &rules_file, const string &ext)
       TagLib::String ts;
       
       ts = f.tag()->artist();
-      if (! ts.isEmpty())
-        {
+      if (! ts.isEmpty() || std::string::npos != required_tag_set.find("@artist"))
+        {           
          string pair = "@artist";
          pair += "=";
          pair += ts.toCString(true);
@@ -341,7 +344,7 @@ void extract_tags (const string &rules_file, const string &ext)
         } 
    
       ts = f.tag()->title();
-      if (! ts.isEmpty())
+      if (! ts.isEmpty() || std::string::npos != required_tag_set.find("@title"))
         {
          string pair = "@title";
          pair += "=";
@@ -350,7 +353,7 @@ void extract_tags (const string &rules_file, const string &ext)
         } 
    
       ts = f.tag()->album();
-      if (! ts.isEmpty())
+      if (! ts.isEmpty() || std::string::npos != required_tag_set.find("@album"))
         {
          string pair = "@album";
          pair += "=";
@@ -359,7 +362,7 @@ void extract_tags (const string &rules_file, const string &ext)
         } 
    
       ts = f.tag()->comment();
-      if (! ts.isEmpty())
+      if (! ts.isEmpty() || std::string::npos != required_tag_set.find("@comment"))
         {
          string pair = "@comment";
          pair += "=";
@@ -368,7 +371,7 @@ void extract_tags (const string &rules_file, const string &ext)
         } 
    
       ts = f.tag()->genre();
-      if (! ts.isEmpty())
+      if (! ts.isEmpty() || std::string::npos != required_tag_set.find("@genre"))
         {
          string pair = "@genre";
          pair += "=";
@@ -379,7 +382,7 @@ void extract_tags (const string &rules_file, const string &ext)
       unsigned int x = 0;
    
       x = f.tag()->year();
-      if (x != 0)
+      if (x != 0 || std::string::npos != required_tag_set.find("@year"))
         {
          string pair = "@year";
          pair += "=";
@@ -388,7 +391,7 @@ void extract_tags (const string &rules_file, const string &ext)
         } 
    
       x = f.tag()->track();
-      if (x != 0)
+      if (x != 0 || std::string::npos != required_tag_set.find("@track"))
         {
          string pair = "@track";
          pair += "=";
@@ -447,7 +450,12 @@ int main (int argc, char *argv[])
      cout << "extract" << endl;
      string rules_file = argv[2];
      string ext = argv[3];
-     extract_tags (rules_file, ext);
+     string required_tag_set = "";
+
+     if (argv[4])
+         required_tag_set = argv[4];
+
+     extract_tags (rules_file, ext, required_tag_set);
     }
   else
   if (command == "rename")


### PR DESCRIPTION
Вот в чем суть фичи.

Когда постоянно собираешь из разных источников музыку в одну папку, то там половина тэгов не заполнена, а половина в кривой кодировке, не говоря уже о случаях когда скачивание ведется с ютуба. Т.е. это скорее случай для разгребания папки Downloads, чем для приведения дискографии к единому виду.

Данный патч позволяет по такой папке сгенерировать файл с правилами, и сидеть в нем в редакторе не отвлекаясь на:

- создание пустых тэгов
- понимание какой блок к какому файлу относится.

Чтение и запись тэгов с добавленными изменениями я проверил, регрессий нет.